### PR TITLE
Basic CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+services:
+  - docker
+before_script:
+  - docker build -t quay.io/justkidding/ci -f build/Dockerfile.ci .
+script:
+  - docker run quay.io/justkidding/ci ./run-tests.sh

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,0 +1,19 @@
+FROM golang:1.11.1 as v8builder
+RUN apt-get update && apt-get install -y \
+    bzip2 \
+    libglib2.0-dev \
+    libxml2 \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+RUN go get -d github.com/dlespiau/v8worker2
+RUN cd $GOPATH/src/github.com/dlespiau/v8worker2 \
+    && ./build.py
+
+FROM golang:1.11.1
+COPY --from=v8builder /go/src/github.com/dlespiau/v8worker2/v8.pc /usr/lib/pkgconfig/
+RUN sed -i \
+     -e 's#Cflags: .*#Cflags: -I/usr/include/v8#' \
+     -e 's#Libs: .*#Libs: /usr/lib/v8/libv8_monolith.a#' \
+     /usr/lib/pkgconfig/v8.pc
+COPY --from=v8builder /go/src/github.com/dlespiau/v8worker2/v8/include /usr/include/v8/
+COPY --from=v8builder /go/src/github.com/dlespiau/v8worker2/out/v8build/obj/libv8_monolith.a /usr/lib/v8/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -1,0 +1,5 @@
+FROM quay.io/justkidding/build
+WORKDIR /go/src/github.com/dlespiau/jk
+COPY . .
+
+CMD ["/bin/bash"]

--- a/build/copy-v8.sh
+++ b/build/copy-v8.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+set -x
+container=$1
+dest=$2
+
+copy() {
+    mkdir -p $dest/`dirname $1`
+    docker cp $container:$1 $dest/$1
+}
+
+copy /usr/lib/pkgconfig/v8.pc
+copy /usr/include/v8
+copy /usr/lib/v8

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/dlespiau/jk
+
+require (
+	github.com/ghodss/yaml v1.0.0
+	github.com/ry/v8worker2 v0.0.0-20180926144945-e3fa6c4d602b
+	gopkg.in/yaml.v2 v2.2.1 // indirect
+)
+
+// go modules need a special branch with a few commits (that have been proposed upstream)
+replace github.com/ry/v8worker2 => github.com/dlespiau/v8worker2 v0.0.0-20181103131220-163e7fd126a2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/dlespiau/v8worker2 v0.0.0-20181103131220-163e7fd126a2 h1:IJy7MPzVpCxbR+XvE28VllLHK105KXtPR04hbBageDw=
+github.com/dlespiau/v8worker2 v0.0.0-20181103131220-163e7fd126a2/go.mod h1:dO8CoeUb377Y1iCjDOhdMJwSuk6ahb75cdkS8LH6Q2U=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ry/v8worker2 v0.0.0-20180926144945-e3fa6c4d602b h1:UAsZ9GQ+23q3t8d79U9vTHgYu8rZKRi6/Edj5f9zWxs=
+github.com/ry/v8worker2 v0.0.0-20180926144945-e3fa6c4d602b/go.mod h1:BdjqPPLlLw26j9NdhD0cQVJL7JvzCk6iWLsdy8NzbpQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+# Build jk
+export GO111MODULE=on
+go install
+
+# Tests, both unit tests and integration tests under /tests
+go test -v ./...


### PR DESCRIPTION
Build jk and run go tests.

It's surprising difficult to do that with v8worker2: we don't want to compile v8 everytime and v8worker2 doesn't play well with the golang universe at the moment. All in all the current solution isn't too bad:

- Compile v8 in a container we push to quay.io (`quay.io/justkidding/buikd). This container is the base container when we want to build jk
- A couple of patches in to v8worker2 to be able to compile it with an already built v8 static library (https://github.com/dlespiau/v8worker2)
- With this we can actually use the go 1.11 go mod! So, yey!
- The CI run is actually happening inside a container built from Dockerfile.ci. That allow us to run the CI pass locally 

Fixes: #2 