### PR TITLE
build: Use the minimal language in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: minimal
 sudo: required
 services:
   - docker


### PR DESCRIPTION
Because we do everything in containers, we need very little things from the
travis image.