### PR TITLE
jk: Print exception when failing to load a module

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func (c resolveContext) resolveModule(specifier, referrer string) int {
 	resolver := resolveContext{worker: c.worker, base: filepath.Dir(path)}
 	err = c.worker.LoadModule(specifier, string(codeBytes), resolver.resolveModule)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
 		return 1
 	}
 	return 0


### PR DESCRIPTION
We definitely want to know why when failing to load a module, make sure to
print the cause!