### PR TITLE
Make resolver relative to supplied script

### DIFF
--- a/run.go
+++ b/run.go
@@ -49,7 +49,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resolver := resolve.NewResolver(worker, ".",
+	resolver := resolve.NewResolver(worker, path.Dir(filename),
 		&resolve.StaticImporter{Specifier: "std", Source: std.Module()},
 		&resolve.FileImporter{},
 	)


### PR DESCRIPTION
The resolver will find imports that are given relative to the module in question. But this has to be kicked off by giving the top-level resolver the path to the script to be run.